### PR TITLE
feat: add swap estimation query and make amm routes optional 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A spot order is fulfilled when the specified price set by the trader aligns with
 - **Stop Loss Functionality**: Enable users to set automated orders that trigger when the asset's price reaches a specified lower limit, minimizing potential losses.
 - **Limit Sell Functionality**: Allow users to set automated orders that execute when the asset's price reaches a specified upper limit, securing profits.
 - **Limit Buy Fuctionality**: Allow user to set automated orders that execute when the limit price is reaches, securing profits.
+- **Market Buy Fuctionality**: Allow users to set automated orders that will execute at market price
 
 ### Margin Order
 

--- a/front_end_script/README.md
+++ b/front_end_script/README.md
@@ -12,7 +12,7 @@ This function allows you to create a new spot order by sending a transaction to 
 
 - `order_amm_routes` (Vec<{`pool_id` : u64, `token_out_denom` : String }>, null): The route for the AMM module to swap the token.
 - `order_price` ({`base_denom`:String, `quote_denom`:String, `rate` :String}): Price relates two assets exchange rate that the user should define
-- `order_type` (String): The type of the order (e.g., "stop_loss", "limit_sell", "limit_buy").
+- `order_type` (String): The type of the order (e.g., "stop_loss", "limit_sell", "limit_buy", "market_buy").
 - `amount_send` (String): The amount of cryptocurrency to send in the order.
 - `denom_send` (String): The denomination of the cryptocurrency to send.
 - `order_target_denom` (String) : the asset that the user want to convert their asset into

--- a/front_end_script/README.md
+++ b/front_end_script/README.md
@@ -10,7 +10,7 @@ This function allows you to create a new spot order by sending a transaction to 
 
 #### Parameters
 
-- `order_amm_routes` (Vec<{`pool_id` : u64, `token_out_denom` : String }>): The route for the AMM module to swap the token.
+- `order_amm_routes` (Vec<{`pool_id` : u64, `token_out_denom` : String }>, null): The route for the AMM module to swap the token.
 - `order_price` ({`base_denom`:String, `quote_denom`:String, `rate` :String}): Price relates two assets exchange rate that the user should define
 - `order_type` (String): The type of the order (e.g., "stop_loss", "limit_sell", "limit_buy").
 - `amount_send` (String): The amount of cryptocurrency to send in the order.
@@ -28,6 +28,15 @@ createSpotOrder(
   "denom_to_send_here"
   "your_target_denom"
 );
+
+createSpotOrder(
+  null,
+  {"base_denom", "quote_denom", "rate"},
+  "order_type",
+  "amount_to_send_here",
+  "denom_to_send_here"
+  "your_target_denom"
+);
 ```
 
 #### Exemple
@@ -35,6 +44,15 @@ createSpotOrder(
 ```js
 createSpotOrder(
   [{ pool_id: 4, token_out_denom: "BTC" }, "AMM_Route_2"],
+  { base_denom: "BTC", quote_denom: "ETH", rate: "0.035" },
+  "limit_buy",
+  "2.5",
+  "ETH",
+  "BTC"
+);
+
+createSpotOrder(
+  null,
   { base_denom: "BTC", quote_denom: "ETH", rate: "0.035" },
   "limit_buy",
   "2.5",
@@ -229,6 +247,32 @@ getMarginOrders("pagination");
 
 ```js
 getMarginOrders({ count_total: true, limit: 10, reverse: false, key: null });
+```
+
+### 10. SwapEstimationByDenom(amount, denom_in, denom_out)
+
+This function retrieves an estimation of the value obtained by swapping one asset for another.
+
+#### Parameters
+
+- `amount` {Coin} : the amount of the value that you want to send or recive.
+- `denom_in` {String} : The asset that you will send.
+- `denom_out` {String} : The asset that you will recive.
+
+#### Usage
+
+```js
+ SwapEstimationByDenom({"amount", "denom"}, "denom_in", "denom_out")
+```
+
+#### Exemple
+
+```js
+SwapEstimationByDenom({
+  amount: { amount: 200, denom: "usdc" },
+  denom_in: "usdc",
+  denom_out: "atom",
+});
 ```
 
 ## Configuration

--- a/front_end_script/upload.js
+++ b/front_end_script/upload.js
@@ -158,3 +158,25 @@ async function getSpotOrders(pagination, order_type, owner_address) {
   );
   console.log(`Result: `, result);
 }
+
+async function SwapEstimationByDenom(amount, denom_in, denom_out) {
+  const sender_wallet = await DirectSecp256k1HdWallet.fromMnemonic(
+    sender.mnemonic,
+    { prefix: "elys" }
+  );
+  const sender_client = await SigningCosmWasmClient.connectWithSigner(
+    rpcEndpoint,
+    sender_wallet
+  );
+  const result = await sender_client.queryContractSmart(
+    trade_shield_contract_addr,
+    {
+      swap_estimation_by_denom: {
+        amount: amount,
+        denom_in: denom_in,
+        denom_out: denom_out,
+      },
+    }
+  );
+  console.log(`Result: `, result);
+}

--- a/src/action/execute/create_spot_order.rs
+++ b/src/action/execute/create_spot_order.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{to_json_binary, Int128, StdResult, Storage, SubMsg};
+use elys_bindings::query_resp::InRouteByDenomResponse;
 
 use crate::msg::ReplyType;
 
@@ -12,7 +13,7 @@ pub fn create_spot_order(
     order_source_denom: String,
     order_target_denom: String,
     order_price: SpotOrderPrice,
-    order_amm_routes: Vec<SwapAmountInRoute>,
+    order_amm_routes: Option<Vec<SwapAmountInRoute>>,
 ) -> Result<Response<ElysMsg>, ContractError> {
     if info.funds.len() != 1 {
         return Err(ContractError::CoinNumber);
@@ -28,13 +29,25 @@ pub fn create_spot_order(
 
     let mut order_vec = SPOT_ORDER.load(deps.storage)?;
 
+    let order_amm_routes = match order_amm_routes {
+        Some(routes) => routes,
+        None => {
+            let querier = ElysQuerier::new(&deps.querier);
+
+            let InRouteByDenomResponse { in_routes } =
+                querier.in_route_by_denom(&order_source_denom, &order_target_denom)?;
+
+            in_routes
+        }
+    };
+
     let new_order: SpotOrder = SpotOrder::new(
         order_type.clone(),
         order_price,
         info.funds[0].clone(),
         info.sender.clone(),
         order_target_denom,
-        order_amm_routes.clone(),
+        order_amm_routes,
         &order_vec,
     );
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -9,6 +9,7 @@ pub mod query {
     mod get_margin_orders;
     mod get_spot_order;
     mod get_spot_orders;
+    mod swap_estimation_by_denom;
 
     use super::*;
 
@@ -22,6 +23,7 @@ pub mod query {
     pub use get_margin_orders::get_margin_orders;
     pub use get_spot_order::get_spot_order;
     pub use get_spot_orders::get_spot_orders;
+    pub use swap_estimation_by_denom::swap_estimation_by_denom;
 }
 
 pub mod execute {

--- a/src/action/query/swap_estimation_by_denom.rs
+++ b/src/action/query/swap_estimation_by_denom.rs
@@ -1,0 +1,16 @@
+use super::*;
+use cosmwasm_std::Coin;
+
+pub fn swap_estimation_by_denom(
+    deps: Deps<ElysQuery>,
+    amount: Coin,
+    denom_in: String,
+    denom_out: String,
+) -> Result<AmmSwapEstimationByDenomResponse, ContractError> {
+    let querier = ElysQuerier::new(&deps.querier);
+
+    let resp: AmmSwapEstimationByDenomResponse =
+        querier.amm_swap_estimation_by_denom(&amount, denom_in, denom_out)?;
+
+    Ok(resp)
+}

--- a/src/entry_point/query.rs
+++ b/src/entry_point/query.rs
@@ -26,5 +26,12 @@ pub fn query(deps: Deps<ElysQuery>, _env: Env, msg: QueryMsg) -> Result<Binary, 
             order_owner,
             order_type,
         )?)?),
+        SwapEstimationByDenom {
+            amount,
+            denom_in,
+            denom_out,
+        } => Ok(to_json_binary(&query::swap_estimation_by_denom(
+            deps, amount, denom_in, denom_out,
+        )?)?),
     }
 }

--- a/src/msg/execute_msg.rs
+++ b/src/msg/execute_msg.rs
@@ -9,7 +9,7 @@ pub enum ExecuteMsg {
         order_source_denom: String,
         order_target_denom: String,
         order_price: SpotOrderPrice,
-        order_amm_routes: Vec<SwapAmountInRoute>,
+        order_amm_routes: Option<Vec<SwapAmountInRoute>>,
     },
     CancelSpotOrder {
         order_id: u64,

--- a/src/msg/query_msg.rs
+++ b/src/msg/query_msg.rs
@@ -2,6 +2,7 @@
 use super::query_resp::*;
 use crate::types::SpotOrderType;
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Coin;
 #[allow(unused_imports)]
 use elys_bindings::query_resp::*;
 use elys_bindings::types::PageRequest;
@@ -24,5 +25,11 @@ pub enum QueryMsg {
         pagination: PageRequest,
         order_owner: Option<String>,
         order_type: Option<SpotOrderType>,
+    },
+    #[returns(AmmSwapEstimationByDenomResponse)]
+    SwapEstimationByDenom {
+        amount: Coin,
+        denom_in: String,
+        denom_out: String,
     },
 }

--- a/src/tests/cancel_spot_order/successful_cancel_order_with_created_order.rs
+++ b/src/tests/cancel_spot_order/successful_cancel_order_with_created_order.rs
@@ -46,7 +46,7 @@ fn successful_cancel_order_with_created_order() {
                 },
                 order_source_denom: "eth".to_owned(),
                 order_target_denom: "btc".to_string(),
-                order_amm_routes: vec![],
+                order_amm_routes: Some(vec![]),
             },
             &coins(45, "eth"),
         )

--- a/src/tests/create_spot_order/coin_number.rs
+++ b/src/tests/create_spot_order/coin_number.rs
@@ -43,7 +43,7 @@ fn coin_number() {
                 },
                 order_source_denom: "eth".to_owned(),
                 order_target_denom: "btc".to_string(),
-                order_amm_routes: vec![],
+                order_amm_routes: Some(vec![]),
             },
             &[],
         )

--- a/src/tests/create_spot_order/not_enough_fund.rs
+++ b/src/tests/create_spot_order/not_enough_fund.rs
@@ -25,7 +25,7 @@ fn not_enough_fund() {
             quote_denom: "eth".to_string(),
             rate: Decimal::from_atomics(Uint128::new(19), 0).unwrap(),
         },
-        order_amm_routes: vec![],
+        order_amm_routes: Some(vec![]),
         order_source_denom: "eth".to_string(),
         order_target_denom: "btc".to_string(),
     };

--- a/src/tests/create_spot_order/order_price_denom.rs
+++ b/src/tests/create_spot_order/order_price_denom.rs
@@ -22,7 +22,7 @@ fn order_price_denom() {
             quote_denom: "usdc".to_string(), // Invalid pair.
             rate: Decimal::from_atomics(Uint128::new(1700), 0).unwrap(),
         },
-        order_amm_routes: vec![],
+        order_amm_routes: Some(vec![]),
         order_source_denom: "eth".to_string(),
         order_target_denom: "btc".to_string(),
     };

--- a/src/tests/create_spot_order/order_same_denom.rs
+++ b/src/tests/create_spot_order/order_same_denom.rs
@@ -20,7 +20,7 @@ fn order_same_denom() {
             quote_denom: "eth".to_string(),
             rate: Decimal::from_atomics(Uint128::new(19), 0).unwrap(),
         },
-        order_amm_routes: vec![],
+        order_amm_routes: Some(vec![]),
         order_source_denom: "eth".to_string(),
         order_target_denom: "eth".to_string(), // Same denomination for base and quote tokens.
     };

--- a/src/tests/create_spot_order/order_wrong_fund.rs
+++ b/src/tests/create_spot_order/order_wrong_fund.rs
@@ -21,7 +21,7 @@ fn order_wrong_fund() {
             quote_denom: "eth".to_string(),
             rate: Decimal::from_atomics(Uint128::new(19), 0).unwrap(),
         },
-        order_amm_routes: vec![],
+        order_amm_routes: Some(vec![]),
         order_source_denom: "usdc".to_string(), // Incorrect source denomination.
         order_target_denom: "btc".to_string(),
     };

--- a/src/tests/create_spot_order/successful_create_limit_buy_order.rs
+++ b/src/tests/create_spot_order/successful_create_limit_buy_order.rs
@@ -46,7 +46,7 @@ fn successful_create_limit_buy_order() {
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_atomics(Uint128::new(30000), 0).unwrap(), // The maximum price of 30000 USDC per BTC.
                 },
-                order_amm_routes: vec![],
+                order_amm_routes: Some(vec![]),
                 order_source_denom: "usdc".to_string(),
                 order_target_denom: "btc".to_string(),
             },

--- a/src/tests/create_spot_order/successful_create_limit_sell_order.rs
+++ b/src/tests/create_spot_order/successful_create_limit_sell_order.rs
@@ -46,7 +46,7 @@ fn successful_create_limit_sell_order() {
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_atomics(Uint128::new(40000), 0).unwrap(), // The desired selling price of 40000 USDC per BTC.
                 },
-                order_amm_routes: vec![],
+                order_amm_routes: Some(vec![]),
                 order_source_denom: "btc".to_string(),
                 order_target_denom: "usdc".to_string(),
             },

--- a/src/tests/create_spot_order/successful_create_market_order.rs
+++ b/src/tests/create_spot_order/successful_create_market_order.rs
@@ -59,7 +59,7 @@ fn successful_create_stop_loss_order() {
                     quote_denom: "".to_string(),
                     rate: Decimal::zero(),
                 },
-                order_amm_routes: vec![SwapAmountInRoute::new(1, "usdc")],
+                order_amm_routes: Some(vec![SwapAmountInRoute::new(1, "usdc")]),
                 order_source_denom: "btc".to_string(),
                 order_target_denom: "usdc".to_string(),
             },

--- a/src/tests/create_spot_order/successful_create_stop_loss_order.rs
+++ b/src/tests/create_spot_order/successful_create_stop_loss_order.rs
@@ -47,7 +47,7 @@ fn successful_create_stop_loss_order() {
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_atomics(Uint128::new(30000), 0).unwrap(), // The trigger price of 30000 USDC per BTC.
                 },
-                order_amm_routes: vec![],
+                order_amm_routes: Some(vec![]),
                 order_source_denom: "btc".to_string(),
                 order_target_denom: "usdc".to_string(),
             },


### PR DESCRIPTION
- [x] made the amm routes optionnal for the creation,
- [x] added a query `SwapEstimationByDenom`
- [x] updated the FE script
- [x] updated  the README.md  