### PR TITLE
fix: marketBuy type

### DIFF
--- a/front_end_script/README.md
+++ b/front_end_script/README.md
@@ -10,7 +10,7 @@ This function allows you to create a new spot order by sending a transaction to 
 
 #### Parameters
 
-- `order_price` ({`base_denom`:String, `quote_denom`:String, `rate` :String}): Price relates two assets exchange rate that the user should define
+- `order_price` ({`base_denom`:String, `quote_denom`:String, `rate` :String} or null): Price relates two assets exchange rate that the user should define, can only be null if the order type is "market_type"
 - `order_type` (String): The type of the order (e.g., "stop_loss", "limit_sell", "limit_buy", "market_buy").
 - `amount_send` (String): The amount of cryptocurrency to send in the order.
 - `denom_send` (String): The denomination of the cryptocurrency to send.
@@ -161,7 +161,7 @@ This function allows you to create a margin order by sending a transaction to th
 - `borrow_asset` (String): The asset to borrow for the margin order.
 - `take_profit_price` (String): The price at which the order will take profit.
 - `order_type` (String): The type of the order (e.g., "stop_loss", "limit_sell", "limit_buy").
-- `trigger_price` ({`base_denom`:String, `quote_denom`:String, `rate` :String}): Price relates two assets exchange rate that the user should define
+- `trigger_price` ({`base_denom`:String, `quote_denom`:String, `rate` :String} or null): Price relates two assets exchange rate that the user should define, can only be null if the order type is "market_type"
 
 #### Usage
 

--- a/scripts/test_amm.sh
+++ b/scripts/test_amm.sh
@@ -26,7 +26,7 @@ addr=$(extract_contract_address elysd q tx $instantiate_hash)
 sleep 2
 elysd tx amm create-pool 100uatom,100uusdc 100000000000uatom,100000000000uusdc --swap-fee=0.00 --exit-fee=0.00 --use-oracle=false  --from=treasury --keyring-backend=test --chain-id=elystestnet-1 --yes --gas=1000000
 sleep 2
-elysd tx wasm exec $addr '{"create_spot_order": { "order_price" : {"base_denom": "uusdc","quote_denom" : "uatom" ,"rate" : "1"}, "order_type" : "stop_loss", "order_target_denom" : "uatom", "order_source_denom" : "uusdc"}}' --from treasury --gas-prices 0.25uelys --gas auto --gas-adjustment 1.3 -b sync -y  --keyring-backend=test --chain-id=elystestnet-1 --amount=200uusdc
+elysd tx wasm exec $addr '{"create_spot_order": { "order_price" : {"base_denom": "uusdc","quote_denom" : "uatom" ,"rate" : "1"}, "order_type" : "market_buy", "order_target_denom" : "uatom", "order_source_denom" : "uusdc"}}' --from treasury --gas-prices 0.25uelys --gas auto --gas-adjustment 1.3 -b sync -y  --keyring-backend=test --chain-id=elystestnet-1 --amount=200uusdc
 sleep 2
 balance_before=$(elysd q bank balances $addr)
 #NOT WORKING ANYMORE

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -52,10 +52,12 @@ pub mod reply {
     mod close_margin_position;
     mod create_margin_order;
     mod spot_order;
+    mod spot_order_market;
 
     pub use close_margin_position::reply_to_close_margin_order;
     pub use create_margin_order::reply_to_create_margin_order;
     pub use spot_order::reply_to_spot_order;
+    pub use spot_order_market::reply_to_spot_order_market;
 }
 
 pub mod sudo {

--- a/src/action/reply/spot_order_market.rs
+++ b/src/action/reply/spot_order_market.rs
@@ -1,0 +1,49 @@
+use cosmwasm_std::{coins, from_json, Binary, DepsMut, StdError, SubMsgResult};
+
+use super::*;
+
+pub fn reply_to_spot_order_market(
+    deps: DepsMut<ElysQuery>,
+    data: Option<Binary>,
+    module_resp: SubMsgResult,
+) -> Result<Response<ElysMsg>, ContractError> {
+    let response = match module_resp.into_result() {
+        Ok(response) => response,
+        Err(err) => return Err(StdError::generic_err(err).into()),
+    };
+
+    let meta_data = match response.data {
+        Some(data) => data,
+        None => return Err(StdError::generic_err("No Data").into()),
+    };
+
+    let amm_response: AmmSwapExactAmountInResp = from_json(&meta_data)?;
+
+    let orders: Vec<SpotOrder> = SPOT_ORDER.load(deps.storage)?;
+
+    let order_id: u64 = match data {
+        Some(order_id) => from_json(&order_id)?,
+        None => return Err(StdError::generic_err("no meta_data".to_string()).into()),
+    };
+
+    let order: SpotOrder = match orders.iter().find(|order| order.order_id == order_id) {
+        Some(order) => order.to_owned(),
+        None => return Err(ContractError::OrderNotFound { order_id }),
+    };
+
+    let bank_msg = BankMsg::Send {
+        to_address: order.owner_address.to_string(),
+        amount: coins(
+            amm_response.token_out_amount.i64() as u128,
+            order.order_target_denom.to_string(),
+        ),
+    };
+
+    let mut processd_spot_orders = PROCESSED_SPOT_ORDER.load(deps.storage)?;
+    processd_spot_orders.push((order_id, bank_msg));
+    PROCESSED_SPOT_ORDER.save(deps.storage, &processd_spot_orders)?;
+
+    let resp: Response<ElysMsg> = Response::new();
+
+    Ok(resp)
+}

--- a/src/action/sudo/process_spot_orders.rs
+++ b/src/action/sudo/process_spot_orders.rs
@@ -69,7 +69,7 @@ fn send_token(
 
 fn check_order(order: &SpotOrder, amm_swap_estimation: &AmmSwapEstimationByDenomResponse) -> bool {
     if order.order_type == OrderType::MarketBuy {
-        return true;
+        return false;
     }
 
     let order_spot_price = match order.order_amount.denom == order.order_price.base_denom {

--- a/src/entry_point/reply.rs
+++ b/src/entry_point/reply.rs
@@ -32,6 +32,7 @@ pub fn reply(
         ReplyType::SpotOrder => reply_to_spot_order(deps, info.data, module_resp),
         ReplyType::MarginBrokerOpenMarketBuy => reply_to_create_margin_order(module_resp),
         ReplyType::MarginBrokerClose => reply_to_close_margin_order(module_resp),
+        ReplyType::SpotOrderMarketBuy => reply_to_spot_order_market(deps, info.data, module_resp),
         _ => return Err(StdError::generic_err("submsg unimplemented").into()),
     }
 }

--- a/src/msg/execute_msg.rs
+++ b/src/msg/execute_msg.rs
@@ -8,7 +8,7 @@ pub enum ExecuteMsg {
         order_type: OrderType,
         order_source_denom: String,
         order_target_denom: String,
-        order_price: OrderPrice,
+        order_price: Option<OrderPrice>,
     },
     CancelSpotOrder {
         order_id: u64,
@@ -26,7 +26,7 @@ pub enum ExecuteMsg {
         borrow_asset: String,
         take_profit_price: Decimal,
         order_type: OrderType,
-        trigger_price: OrderPrice,
+        trigger_price: Option<OrderPrice>,
     },
 
     CancelMarginOrder {

--- a/src/msg/reply_type.rs
+++ b/src/msg/reply_type.rs
@@ -6,4 +6,5 @@ pub enum ReplyType {
     MarginBrokerOpen,
     MarginBrokerClose,
     MarginBrokerOpenMarketBuy,
+    SpotOrderMarketBuy,
 }

--- a/src/tests/cancel_margin_order/succesful_cancel_an_order.rs
+++ b/src/tests/cancel_margin_order/succesful_cancel_an_order.rs
@@ -17,11 +17,11 @@ fn succesful_cancel_an_order() {
             &Decimal::one(),
             &Decimal::one(),
             &OrderType::LimitBuy,
-            &OrderPrice {
+            &Some(OrderPrice {
                 base_denom: "btc".to_string(),
                 quote_denom: "usdc".to_string(),
                 rate: Decimal::one(),
-            },
+            }),
             &vec![],
         )],
     };

--- a/src/tests/cancel_margin_order/unauthorize.rs
+++ b/src/tests/cancel_margin_order/unauthorize.rs
@@ -17,11 +17,11 @@ fn unauthorize() {
             &Decimal::one(),
             &Decimal::one(),
             &OrderType::LimitBuy,
-            &OrderPrice {
+            &Some(OrderPrice {
                 base_denom: "btc".to_string(),
                 quote_denom: "usdc".to_string(),
                 rate: Decimal::one(),
-            },
+            }),
             &vec![],
         )],
     };

--- a/src/tests/cancel_spot_order/process_spot_order_processing.rs
+++ b/src/tests/cancel_spot_order/process_spot_order_processing.rs
@@ -24,11 +24,11 @@ fn process_spot_order_processing() {
     // Create a "limit buy" order (dummy order) with a specific rate and balance.
     let dummy_order = SpotOrder::new(
         OrderType::LimitBuy,
-        OrderPrice {
+        Some(OrderPrice {
             base_denom: "ubtc".to_string(),
             quote_denom: "usdc".to_string(),
             rate: Decimal::from_atomics(Uint128::new(38), 0).unwrap(), // Rate at which ubtc will be bought (38 USDC per ubtc).
-        },
+        }),
         coin(120, "usdc"), // 120 USDC to be used for buying.
         Addr::unchecked("user"),
         "ubtc".to_string(),

--- a/src/tests/cancel_spot_order/successful_cancel_order_with_created_order.rs
+++ b/src/tests/cancel_spot_order/successful_cancel_order_with_created_order.rs
@@ -45,11 +45,11 @@ fn successful_cancel_order_with_created_order() {
             addr.clone(),
             &ExecuteMsg::CreateSpotOrder {
                 order_type: OrderType::StopLoss,
-                order_price: OrderPrice {
+                order_price: Some(OrderPrice {
                     rate: Decimal::from_atomics(Uint128::new(18), 0).unwrap(),
                     base_denom: "btc".to_string(),
                     quote_denom: "eth".to_string(),
-                },
+                }),
                 order_source_denom: "eth".to_owned(),
                 order_target_denom: "btc".to_string(),
             },

--- a/src/tests/create_margin_order/coin_number.rs
+++ b/src/tests/create_margin_order/coin_number.rs
@@ -41,11 +41,11 @@ fn coin_number() {
                 borrow_asset: "uatom".to_string(),
                 take_profit_price: Decimal::from_atomics(Uint128::new(500), 2).unwrap(),
                 order_type: OrderType::LimitSell,
-                trigger_price: OrderPrice {
+                trigger_price: Some(OrderPrice {
                     base_denom: "uatom".to_string(),
                     quote_denom: "uusdc".to_string(),
                     rate: Decimal::from_str("1.5").unwrap(),
-                },
+                }),
             },
             &[],
         )

--- a/src/tests/create_margin_order/collateral_amount.rs
+++ b/src/tests/create_margin_order/collateral_amount.rs
@@ -43,11 +43,11 @@ fn collateral_amount() {
                 borrow_asset: "uatom".to_string(),
                 take_profit_price: Decimal::from_atomics(Uint128::new(500), 2).unwrap(),
                 order_type: OrderType::StopLoss,
-                trigger_price: OrderPrice {
+                trigger_price: Some(OrderPrice {
                     base_denom: "uatom".to_string(),
                     quote_denom: "uusdc".to_string(),
                     rate: Decimal::from_str("1.25").unwrap(),
-                },
+                }),
             },
             &[coin(45, "usdc")],
         )

--- a/src/tests/create_margin_order/non_usdc_collateral_for_short.rs
+++ b/src/tests/create_margin_order/non_usdc_collateral_for_short.rs
@@ -45,11 +45,11 @@ fn non_usdc_collateral_for_short() {
                 borrow_asset: "btc".to_string(),
                 take_profit_price: Decimal::from_atomics(Uint128::new(200), 2).unwrap(),
                 order_type: OrderType::LimitSell,
-                trigger_price: OrderPrice {
+                trigger_price: Some(OrderPrice {
                     base_denom: "btc".to_string(),
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_str("1.7").unwrap(),
-                },
+                }),
             },
             &coins(10, "btc"), // User's BTC balance.
         )

--- a/src/tests/create_margin_order/successful_create_margin_market_order.rs
+++ b/src/tests/create_margin_order/successful_create_margin_market_order.rs
@@ -43,11 +43,11 @@ fn successful_create_margin_market_order() {
             borrow_asset: "btc".to_string(),
             take_profit_price: Decimal::from_atomics(Uint128::new(200), 2).unwrap(),
             order_type: OrderType::MarketBuy,
-            trigger_price: OrderPrice {
+            trigger_price: Some(OrderPrice {
                 base_denom: "btc".to_string(),
                 quote_denom: "usdc".to_string(),
                 rate: Decimal::from_str("1.7").unwrap(),
-            },
+            }),
         },
         &coins(10, "btc"), // User's BTC balance.
     )

--- a/src/tests/create_margin_order/successful_create_margin_order.rs
+++ b/src/tests/create_margin_order/successful_create_margin_order.rs
@@ -46,11 +46,11 @@ fn successful_create_margin_order() {
                 borrow_asset: "btc".to_string(),
                 take_profit_price: Decimal::from_atomics(Uint128::new(200), 2).unwrap(),
                 order_type: OrderType::LimitSell,
-                trigger_price: OrderPrice {
+                trigger_price: Some(OrderPrice {
                     base_denom: "btc".to_string(),
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_str("1.7").unwrap(),
-                },
+                }),
             },
             &coins(10, "btc"), // User's BTC balance.
         )

--- a/src/tests/create_spot_order/coin_number.rs
+++ b/src/tests/create_spot_order/coin_number.rs
@@ -36,11 +36,11 @@ fn coin_number() {
             addr,
             &ExecuteMsg::CreateSpotOrder {
                 order_type: OrderType::StopLoss,
-                order_price: OrderPrice {
+                order_price: Some(OrderPrice {
                     rate: Decimal::from_atomics(Uint128::new(17), 0).unwrap(),
                     base_denom: "btc".to_string(),
                     quote_denom: "eth".to_string(),
-                },
+                }),
                 order_source_denom: "eth".to_owned(),
                 order_target_denom: "btc".to_string(),
             },

--- a/src/tests/create_spot_order/not_enough_fund.rs
+++ b/src/tests/create_spot_order/not_enough_fund.rs
@@ -20,11 +20,11 @@ fn not_enough_fund() {
     // Define the parameters for creating an order with insufficient funds.
     let create_order_msg = ExecuteMsg::CreateSpotOrder {
         order_type: OrderType::LimitSell,
-        order_price: OrderPrice {
+        order_price: Some(OrderPrice {
             base_denom: "btc".to_string(),
             quote_denom: "eth".to_string(),
             rate: Decimal::from_atomics(Uint128::new(19), 0).unwrap(),
-        },
+        }),
 
         order_source_denom: "eth".to_string(),
         order_target_denom: "btc".to_string(),

--- a/src/tests/create_spot_order/order_price_denom.rs
+++ b/src/tests/create_spot_order/order_price_denom.rs
@@ -17,11 +17,11 @@ fn order_price_denom() {
 
     let create_order_msg = ExecuteMsg::CreateSpotOrder {
         order_type: OrderType::LimitSell,
-        order_price: OrderPrice {
+        order_price: Some(OrderPrice {
             base_denom: "eth".to_string(),
             quote_denom: "usdc".to_string(), // Invalid pair.
             rate: Decimal::from_atomics(Uint128::new(1700), 0).unwrap(),
-        },
+        }),
 
         order_source_denom: "eth".to_string(),
         order_target_denom: "btc".to_string(),

--- a/src/tests/create_spot_order/order_same_denom.rs
+++ b/src/tests/create_spot_order/order_same_denom.rs
@@ -15,11 +15,11 @@ fn order_same_denom() {
 
     let create_order_msg = ExecuteMsg::CreateSpotOrder {
         order_type: OrderType::LimitSell,
-        order_price: OrderPrice {
+        order_price: Some(OrderPrice {
             base_denom: "btc".to_string(),
             quote_denom: "eth".to_string(),
             rate: Decimal::from_atomics(Uint128::new(19), 0).unwrap(),
-        },
+        }),
 
         order_source_denom: "eth".to_string(),
         order_target_denom: "eth".to_string(), // Same denomination for base and quote tokens.

--- a/src/tests/create_spot_order/order_wrong_fund.rs
+++ b/src/tests/create_spot_order/order_wrong_fund.rs
@@ -16,11 +16,11 @@ fn order_wrong_fund() {
 
     let create_order_msg = ExecuteMsg::CreateSpotOrder {
         order_type: OrderType::LimitSell,
-        order_price: OrderPrice {
+        order_price: Some(OrderPrice {
             base_denom: "btc".to_string(),
             quote_denom: "eth".to_string(),
             rate: Decimal::from_atomics(Uint128::new(19), 0).unwrap(),
-        },
+        }),
 
         order_source_denom: "usdc".to_string(), // Incorrect source denomination.
         order_target_denom: "btc".to_string(),

--- a/src/tests/create_spot_order/successful_create_limit_buy_order.rs
+++ b/src/tests/create_spot_order/successful_create_limit_buy_order.rs
@@ -47,11 +47,11 @@ fn successful_create_limit_buy_order() {
             addr.clone(),
             &ExecuteMsg::CreateSpotOrder {
                 order_type: OrderType::LimitBuy,
-                order_price: OrderPrice {
+                order_price: Some(OrderPrice {
                     base_denom: "btc".to_string(),
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_atomics(Uint128::new(30000), 0).unwrap(), // The maximum price of 30000 USDC per BTC.
-                },
+                }),
 
                 order_source_denom: "usdc".to_string(),
                 order_target_denom: "btc".to_string(),

--- a/src/tests/create_spot_order/successful_create_limit_sell_order.rs
+++ b/src/tests/create_spot_order/successful_create_limit_sell_order.rs
@@ -47,11 +47,11 @@ fn successful_create_limit_sell_order() {
             addr.clone(),
             &ExecuteMsg::CreateSpotOrder {
                 order_type: OrderType::LimitSell,
-                order_price: OrderPrice {
+                order_price: Some(OrderPrice {
                     base_denom: "btc".to_string(),
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_atomics(Uint128::new(40000), 0).unwrap(), // The desired selling price of 40000 USDC per BTC.
-                },
+                }),
 
                 order_source_denom: "btc".to_string(),
                 order_target_denom: "usdc".to_string(),

--- a/src/tests/create_spot_order/successful_create_market_order.rs
+++ b/src/tests/create_spot_order/successful_create_market_order.rs
@@ -56,11 +56,7 @@ fn successful_create_stop_loss_order() {
             &ExecuteMsg::CreateSpotOrder {
                 order_type: OrderType::MarketBuy,
                 // Empty order price - not utilized in market orders
-                order_price: OrderPrice {
-                    base_denom: "".to_string(),
-                    quote_denom: "".to_string(),
-                    rate: Decimal::zero(),
-                },
+                order_price: None,
                 order_source_denom: "btc".to_string(),
                 order_target_denom: "usdc".to_string(),
             },

--- a/src/tests/create_spot_order/successful_create_stop_loss_order.rs
+++ b/src/tests/create_spot_order/successful_create_stop_loss_order.rs
@@ -48,11 +48,11 @@ fn successful_create_stop_loss_order() {
             addr.clone(),
             &ExecuteMsg::CreateSpotOrder {
                 order_type: OrderType::StopLoss,
-                order_price: OrderPrice {
+                order_price: Some(OrderPrice {
                     base_denom: "btc".to_string(),
                     quote_denom: "usdc".to_string(),
                     rate: Decimal::from_atomics(Uint128::new(30000), 0).unwrap(), // The trigger price of 30000 USDC per BTC.
-                },
+                }),
 
                 order_source_denom: "btc".to_string(),
                 order_target_denom: "usdc".to_string(),

--- a/src/tests/get_margin_order/successful_query_message.rs
+++ b/src/tests/get_margin_order/successful_query_message.rs
@@ -15,11 +15,11 @@ fn successful_query_message() {
         &Decimal::one(),
         &Decimal::one(),
         &OrderType::LimitBuy,
-        &OrderPrice {
+        &Some(OrderPrice {
             base_denom: "btc".to_string(),
             quote_denom: "usdc".to_string(),
             rate: Decimal::one(),
-        },
+        }),
         &vec![],
     );
 

--- a/src/tests/process_spot_order/succesful_process_limit_buy_order.rs
+++ b/src/tests/process_spot_order/succesful_process_limit_buy_order.rs
@@ -34,11 +34,11 @@ fn successful_process_limit_buy_order() {
     // Create a "limit buy" order (dummy order) with a specific rate and balance.
     let dummy_order = SpotOrder::new(
         OrderType::LimitBuy,
-        OrderPrice {
+        Some(OrderPrice {
             base_denom: "ubtc".to_string(),
             quote_denom: "usdc".to_string(),
             rate: Decimal::from_atomics(Uint128::new(38), 0).unwrap(), // Rate at which ubtc will be bought (38 USDC per ubtc).
-        },
+        }),
         coin(120, "usdc"), // 120 USDC to be used for buying.
         Addr::unchecked("user"),
         "ubtc".to_string(),

--- a/src/tests/process_spot_order/successful_process_limit_sell_order.rs
+++ b/src/tests/process_spot_order/successful_process_limit_sell_order.rs
@@ -38,11 +38,11 @@ fn successful_process_limit_sell_order() {
     // Create a "limit sell" order (dummy order) with a specific rate and balance.
     let dummy_order = SpotOrder::new(
         OrderType::LimitSell,
-        OrderPrice {
+        Some(OrderPrice {
             base_denom: "btc".to_string(),
             quote_denom: "usdc".to_string(),
             rate: Decimal::from_atomics(Uint128::new(30000), 0).unwrap(), // Rate at which BTC will be sold (30,000 USDC per BTC).
-        },
+        }),
         coin(2, "btc"), // 2 BTC to be sold.
         Addr::unchecked("user"),
         "usdc".to_string(),

--- a/src/tests/process_spot_order/successful_process_stop_loss_order.rs
+++ b/src/tests/process_spot_order/successful_process_stop_loss_order.rs
@@ -39,11 +39,11 @@ fn successful_process_stop_loss_order() {
     // Create a "stop-loss" order (dummy order) with trigger price and balance.
     let dummy_order = SpotOrder::new(
         OrderType::StopLoss,
-        OrderPrice {
+        Some(OrderPrice {
             base_denom: "btc".to_string(),
             quote_denom: "usdc".to_string(),
             rate: Decimal::from_atomics(Uint128::new(20000), 0).unwrap(), // Trigger price of 20,000 USDC per BTC.
-        },
+        }),
         coin(2, "btc"), // 2 BTC to be sold.
         Addr::unchecked("user"),
         "usdc".to_string(),

--- a/src/types/margin_order.rs
+++ b/src/types/margin_order.rs
@@ -26,12 +26,21 @@ impl MarginOrder {
         leverage: &Decimal,
         take_profit_price: &Decimal,
         order_type: &OrderType,
-        trigger_price: &OrderPrice,
+        trigger_price: &Option<OrderPrice>,
         order_vec: &Vec<MarginOrder>,
     ) -> Self {
         let order_id: u64 = match order_vec.iter().max_by_key(|s| s.order_id) {
             Some(x) => x.order_id + 1,
             None => 0,
+        };
+
+        let trigger_price = match trigger_price {
+            Some(trigger_price) => trigger_price.to_owned(),
+            None => OrderPrice {
+                base_denom: "".to_string(),
+                quote_denom: "".to_string(),
+                rate: Decimal::zero(),
+            },
         };
 
         Self {
@@ -43,7 +52,7 @@ impl MarginOrder {
             leverage: leverage.to_owned(),
             take_profit_price: take_profit_price.to_owned(),
             order_type: order_type.to_owned(),
-            trigger_price: trigger_price.to_owned(),
+            trigger_price,
         }
     }
 }

--- a/src/types/spot_order/impls/new.rs
+++ b/src/types/spot_order/impls/new.rs
@@ -1,10 +1,10 @@
 use crate::types::*;
-use cosmwasm_std::{Addr, Coin};
+use cosmwasm_std::{Addr, Coin, Decimal};
 
 impl SpotOrder {
     pub fn new(
         order_type: OrderType,
-        order_price: OrderPrice,
+        order_price: Option<OrderPrice>,
         order_amount: Coin,
         owner_address: Addr,
         order_target_denom: String,
@@ -13,6 +13,15 @@ impl SpotOrder {
         let order_id: u64 = match order_vec.iter().max_by_key(|s| s.order_id) {
             Some(x) => x.order_id + 1,
             None => 0,
+        };
+
+        let order_price = match order_price {
+            Some(order_price) => order_price,
+            None => OrderPrice {
+                base_denom: "".to_owned(),
+                quote_denom: "".to_owned(),
+                rate: Decimal::zero(),
+            },
         };
 
         SpotOrder {


### PR DESCRIPTION
- [x] x/clock cannot process the same market order at each block
- [x] `order_price` can be optional if the order type is `market_buy` 
- [x] tests fix
- [x] doc updated 